### PR TITLE
feat: use fragment to return multiple elements

### DIFF
--- a/src/components/ListGroup.tsx
+++ b/src/components/ListGroup.tsx
@@ -1,12 +1,15 @@
 function ListGroup() {
   return (
-    <ul className="list-group">
-      <li className="list-group-item">An item</li>
-      <li className="list-group-item">A second item</li>
-      <li className="list-group-item">A third item</li>
-      <li className="list-group-item">A fourth item</li>
-      <li className="list-group-item">And a fifth one</li>
-    </ul>
+    <>
+      <h1>List</h1>
+      <ul className="list-group">
+        <li className="list-group-item">An item</li>
+        <li className="list-group-item">A second item</li>
+        <li className="list-group-item">A third item</li>
+        <li className="list-group-item">A fourth item</li>
+        <li className="list-group-item">And a fifth one</li>
+      </ul>
+    </>
   );
 }
 


### PR DESCRIPTION
Demonstrate usability of Fragment.
- Empty angular brackets tells REACT to wrap all the children in Fragment. 
- No need to import Fragment explicitly in this case.